### PR TITLE
[FIX] Revert missing label

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -54,6 +54,10 @@
 
 - id: discover
   translation: "Discover this project"
+
+- id: discoverModules
+  translation: "Discover this module"
+
 - id: continueReading
   translation: "Continue reading"
 


### PR DESCRIPTION
This PR reverts back a button label from the old `psy6983_2021`

Before:
![image](https://github.com/school-brainhack/school-brainhack.github.io/assets/562525/86253bdb-399c-4b1e-8294-934055e31d1b)

After:
![image](https://github.com/school-brainhack/school-brainhack.github.io/assets/562525/457a445b-0871-4b40-901d-b53922a18501)
