### PR TITLE
Corrected a typo in the email address

### DIFF
--- a/content/en/modules/git_github/index.md
+++ b/content/en/modules/git_github/index.md
@@ -32,7 +32,7 @@ The prerequisites to take this module are:
  * the [installation](/modules/installation) module.
  * the [introduction to the terminal](/modules/introduction_to_terminal) module.
 
-If you have any questions regarding the module content please ask them in the relevant module channel on the school Discord server. If you do not have access to the server and would like to join, please send us an email at school [dot] brainhack [at] gmail [dot] com.
+If you have any questions regarding the module content please ask them in the relevant module channel on the school Discord server. If you do not have access to the server and would like to join, please send us an email at school.brainhack@gmail.com.
 
 ## Resources
 


### PR DESCRIPTION
In the Using Git and GitHub module there was a typo in the email address 