### PR TITLE
Add the spinal cord module into the 'weeks' page

### DIFF
--- a/content/en/weeks/index.md
+++ b/content/en/weeks/index.md
@@ -60,6 +60,7 @@ Short exercises need to be completed at the end of each tutorial. """
   * [Working with MNE-Python and EEG-BIDS](/modules/mne_python)
   * [Neuroimaging data and file structures in Python](/modules/nibabel)
   * [Introduction to dMRI](/modules/dmri_intro)
+  * [Introduction to spinal cord MRI analysis](/modules/spinal_cord)
  """
 
 [[week]]


### PR DESCRIPTION
This is a tiny PR adding the recently introduced [spinal cord module](https://github.com/school-brainhack/school-brainhack.github.io/pull/310) into the [weeks](https://school-brainhack.github.io/weeks/) page. I included the spinal cord module in week 2.

Resolves: https://github.com/school-brainhack/school-brainhack.github.io/pull/310#issuecomment-2111405998